### PR TITLE
bugfix usage of Struct in Ruby 3.1 / 3.2 to avoid lots of warnings

### DIFF
--- a/lib/best_in_place/display_methods.rb
+++ b/lib/best_in_place/display_methods.rb
@@ -30,15 +30,15 @@ module BestInPlace
     end
 
     def add_model_method(klass, attr, display_as)
-      model_attributes(klass)[attr.to_s] = Renderer.new method: display_as.to_sym, type: :model
+      model_attributes(klass)[attr.to_s] = Renderer.new({ method: display_as.to_sym, type: :model })
     end
 
     def add_helper_method(klass, attr, helper_method, helper_options = nil)
-      model_attributes(klass)[attr.to_s] = Renderer.new method: helper_method.to_sym, type: :helper, attr: attr, helper_options: helper_options
+      model_attributes(klass)[attr.to_s] = Renderer.new({ method: helper_method.to_sym, type: :helper, attr: attr, helper_options: helper_options })
     end
 
     def add_helper_proc(klass, attr, helper_proc)
-      model_attributes(klass)[attr.to_s] = Renderer.new type: :proc, attr: attr, proc: helper_proc
+      model_attributes(klass)[attr.to_s] = Renderer.new({ type: :proc, attr: attr, proc: helper_proc })
     end
 
     def model_attributes(klass)


### PR DESCRIPTION
I got a ton of warnings on my logfile:

```
/Users/florian/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/best_in_place-c0bc9c8ad3e1/lib/best_in_place/display_methods.rb:41: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/florian/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/best_in_place-c0bc9c8ad3e1/lib/best_in_place/display_methods.rb:41: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/florian/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/best_in_place-c0bc9c8ad3e1/lib/best_in_place/display_methods.rb:41: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/florian/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/best_in_place-c0bc9c8ad3e1/lib/best_in_place/display_methods.rb:41: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/florian/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/best_in_place-c0bc9c8ad3e1/lib/best_in_place/display_methods.rb:41: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/florian/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/best_in_place-c0bc9c8ad3e1/lib/best_in_place/display_methods.rb:41: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/florian/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/best_in_place-c0bc9c8ad3e1/lib/best_in_place/display_methods.rb:41: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/florian/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/best_in_place-c0bc9c8ad3e1/lib/best_in_place/display_methods.rb:41: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/florian/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/best_in_place-c0bc9c8ad3e1/lib/best_in_place/display_methods.rb:41: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/florian/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/best_in_place-c0bc9c8ad3e1/lib/best_in_place/display_methods.rb:41: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
```

The fix looks easy enough, what do you think @kholbekj ?